### PR TITLE
Fix super class의 필드 접근 못하는 이슈 해결

### DIFF
--- a/spring-batch-querydsl-integration-test/src/main/java/org/springframework/batch/item/querydsl/integrationtest/entity/EntityAuditing.java
+++ b/spring-batch-querydsl-integration-test/src/main/java/org/springframework/batch/item/querydsl/integrationtest/entity/EntityAuditing.java
@@ -1,0 +1,21 @@
+package org.springframework.batch.item.querydsl.integrationtest.entity;
+
+import javax.persistence.EntityListeners;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.MappedSuperclass;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+@EntityListeners(AuditingEntityListener.class)
+@MappedSuperclass
+abstract class EntityAuditing {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    public Long getId() {
+        return id;
+    }
+}

--- a/spring-batch-querydsl-integration-test/src/main/java/org/springframework/batch/item/querydsl/integrationtest/entity/Foo.java
+++ b/spring-batch-querydsl-integration-test/src/main/java/org/springframework/batch/item/querydsl/integrationtest/entity/Foo.java
@@ -1,0 +1,20 @@
+package org.springframework.batch.item.querydsl.integrationtest.entity;
+
+import javax.persistence.Entity;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+public class Foo extends EntityAuditing {
+
+
+    private String name;
+
+    public Foo(String name) {
+        this.name = name;
+    }
+}

--- a/spring-batch-querydsl-integration-test/src/main/java/org/springframework/batch/item/querydsl/integrationtest/entity/FooRepository.java
+++ b/spring-batch-querydsl-integration-test/src/main/java/org/springframework/batch/item/querydsl/integrationtest/entity/FooRepository.java
@@ -1,0 +1,6 @@
+package org.springframework.batch.item.querydsl.integrationtest.entity;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface FooRepository extends JpaRepository<Foo, Long> {
+}

--- a/spring-batch-querydsl-integration-test/src/test/java/org/springframework/batch/item/querydsl/integrationtest/reader/QuerydslNoOffsetPagingItemReaderGroupByTest.java
+++ b/spring-batch-querydsl-integration-test/src/test/java/org/springframework/batch/item/querydsl/integrationtest/reader/QuerydslNoOffsetPagingItemReaderGroupByTest.java
@@ -1,5 +1,11 @@
 package org.springframework.batch.item.querydsl.integrationtest.reader;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.batch.item.querydsl.integrationtest.entity.QFoo.foo;
+import static org.springframework.batch.item.querydsl.integrationtest.entity.QManufacture.manufacture;
+
+import java.time.LocalDate;
+import javax.persistence.EntityManagerFactory;
 import org.junit.After;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -9,7 +15,6 @@ import org.springframework.batch.item.querydsl.integrationtest.entity.Foo;
 import org.springframework.batch.item.querydsl.integrationtest.entity.FooRepository;
 import org.springframework.batch.item.querydsl.integrationtest.entity.Manufacture;
 import org.springframework.batch.item.querydsl.integrationtest.entity.ManufactureRepository;
-import org.springframework.batch.item.querydsl.integrationtest.entity.QFoo;
 import org.springframework.batch.item.querydsl.integrationtest.job.QuerydslNoOffsetPagingItemReaderConfiguration;
 import org.springframework.batch.item.querydsl.reader.QuerydslNoOffsetPagingItemReader;
 import org.springframework.batch.item.querydsl.reader.expression.Expression;
@@ -18,13 +23,6 @@ import org.springframework.batch.item.querydsl.reader.options.QuerydslNoOffsetSt
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.junit4.SpringRunner;
-
-import javax.persistence.EntityManagerFactory;
-import java.time.LocalDate;
-
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.springframework.batch.item.querydsl.integrationtest.entity.QFoo.foo;
-import static org.springframework.batch.item.querydsl.integrationtest.entity.QManufacture.manufacture;
 
 @RunWith(SpringRunner.class)
 @SpringBootTest(classes = {TestBatchConfig.class, QuerydslNoOffsetPagingItemReaderConfiguration.class})

--- a/spring-batch-querydsl-integration-test/src/test/java/org/springframework/batch/item/querydsl/integrationtest/reader/QuerydslNoOffsetPagingItemReaderGroupByTest.java
+++ b/spring-batch-querydsl-integration-test/src/test/java/org/springframework/batch/item/querydsl/integrationtest/reader/QuerydslNoOffsetPagingItemReaderGroupByTest.java
@@ -40,6 +40,7 @@ public class QuerydslNoOffsetPagingItemReaderGroupByTest {
     @After
     public void after() throws Exception {
         manufactureRepository.deleteAllInBatch();
+        fooRepository.deleteAllInBatch();
     }
 
     @Test

--- a/spring-batch-querydsl-integration-test/src/test/java/org/springframework/batch/item/querydsl/integrationtest/reader/QuerydslNoOffsetPagingItemReaderGroupByTest.java
+++ b/spring-batch-querydsl-integration-test/src/test/java/org/springframework/batch/item/querydsl/integrationtest/reader/QuerydslNoOffsetPagingItemReaderGroupByTest.java
@@ -5,11 +5,15 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.batch.item.ExecutionContext;
 import org.springframework.batch.item.querydsl.integrationtest.TestBatchConfig;
+import org.springframework.batch.item.querydsl.integrationtest.entity.Foo;
+import org.springframework.batch.item.querydsl.integrationtest.entity.FooRepository;
 import org.springframework.batch.item.querydsl.integrationtest.entity.Manufacture;
 import org.springframework.batch.item.querydsl.integrationtest.entity.ManufactureRepository;
+import org.springframework.batch.item.querydsl.integrationtest.entity.QFoo;
 import org.springframework.batch.item.querydsl.integrationtest.job.QuerydslNoOffsetPagingItemReaderConfiguration;
 import org.springframework.batch.item.querydsl.reader.QuerydslNoOffsetPagingItemReader;
 import org.springframework.batch.item.querydsl.reader.expression.Expression;
+import org.springframework.batch.item.querydsl.reader.options.QuerydslNoOffsetNumberOptions;
 import org.springframework.batch.item.querydsl.reader.options.QuerydslNoOffsetStringOptions;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -19,6 +23,7 @@ import javax.persistence.EntityManagerFactory;
 import java.time.LocalDate;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.batch.item.querydsl.integrationtest.entity.QFoo.foo;
 import static org.springframework.batch.item.querydsl.integrationtest.entity.QManufacture.manufacture;
 
 @RunWith(SpringRunner.class)
@@ -27,6 +32,9 @@ public class QuerydslNoOffsetPagingItemReaderGroupByTest {
 
     @Autowired
     private ManufactureRepository manufactureRepository;
+
+    @Autowired
+    private FooRepository fooRepository;
 
     @Autowired
     private EntityManagerFactory emf;
@@ -102,5 +110,28 @@ public class QuerydslNoOffsetPagingItemReaderGroupByTest {
         assertThat(read1.getName()).isEqualTo(expected2);
         assertThat(read2.getName()).isEqualTo(expected1);
         assertThat(read3).isNull();
+    }
+
+    @Test
+    public void super_class의_필드_사용_가능하다() throws Exception {
+        //given
+        int chunkSize = 1;
+        final Long fooId = fooRepository.save(new Foo("foo1")).getId();
+
+        final QuerydslNoOffsetNumberOptions<Foo, Long> options = new QuerydslNoOffsetNumberOptions<>(foo.id, Expression.DESC);
+        final QuerydslNoOffsetPagingItemReader<Foo> reader = new QuerydslNoOffsetPagingItemReader<>(emf,
+            chunkSize,
+            options,
+            queryFactory -> queryFactory
+                .selectFrom(foo)
+                .where(foo.id.eq(fooId))
+        );
+        reader.open(new ExecutionContext());
+
+        //when
+        final Foo foo = reader.read();
+
+        //then
+        assertThat(foo.getId()).isEqualTo(fooId);
     }
 }

--- a/spring-batch-querydsl-reader/src/main/java/org/springframework/batch/item/querydsl/reader/options/QuerydslNoOffsetOptions.java
+++ b/spring-batch-querydsl-reader/src/main/java/org/springframework/batch/item/querydsl/reader/options/QuerydslNoOffsetOptions.java
@@ -41,7 +41,20 @@ public abstract class QuerydslNoOffsetOptions<T> {
 
     protected Object getFiledValue(T item) {
         try {
-            Field field = item.getClass().getDeclaredField(fieldName);
+            final Class<?> itemClass = item.getClass();
+            if (itemClass.getSuperclass() != null) {
+                final Class<?> superclass = itemClass.getSuperclass();
+                final Field[] superClassFields = superclass.getDeclaredFields();
+                for (Field field : superClassFields) {
+                    if (field.getName().equals(fieldName)) {
+                        field.setAccessible(true);
+                        superclass.getDeclaredField("id");
+                        return field.get(item);
+                    }
+                }
+            }
+
+            final Field field = itemClass.getDeclaredField("id");
             field.setAccessible(true);
             return field.get(item);
         } catch (NoSuchFieldException | IllegalAccessException e) {


### PR DESCRIPTION
##  증상
```java
@EntityListeners(AuditingEntityListener.class)
@MappedSuperclass
abstract class EntityAuditing {

    @Id
    @GeneratedValue(strategy = GenerationType.IDENTITY)
    private Long id;

    public Long getId() {
        return id;
    }
}


@Entity
@NoArgsConstructor(access = AccessLevel.PROTECTED)
@Getter
public class Foo extends EntityAuditing {


    private String name;

    public Foo(String name) {
        this.name = name;
    }
}
```
* 사용할 필드가 super class에 있는 경우 아래 Error Log에 있는 예외가 발생
## Error Log

<details>
    <summary>자세히</summary>

```
java.lang.NoSuchFieldException: id
	at java.base/java.lang.Class.getDeclaredField(Class.java:2411) ~[na:na]
	at org.springframework.batch.item.querydsl.reader.options.QuerydslNoOffsetOptions.getFiledValue(QuerydslNoOffsetOptions.java:44) ~[spring-batch-querydsl-reader-2.4.8.jar:na]
	at org.springframework.batch.item.querydsl.reader.options.QuerydslNoOffsetNumberOptions.resetCurrentId(QuerydslNoOffsetNumberOptions.java:102) ~[spring-batch-querydsl-reader-2.4.8.jar:na]
	at org.springframework.batch.item.querydsl.reader.QuerydslNoOffsetPagingItemReader.resetCurrentIdIfNotLastPage(QuerydslNoOffsetPagingItemReader.java:58) ~[spring-batch-querydsl-reader-2.4.8.jar:na]
	at org.springframework.batch.item.querydsl.reader.QuerydslNoOffsetPagingItemReader.doReadPage(QuerydslNoOffsetPagingItemReader.java:44) ~[spring-batch-querydsl-reader-2.4.8.jar:na]
	at org.springframework.batch.item.database.AbstractPagingItemReader.doRead(AbstractPagingItemReader.java:110) ~[spring-batch-infrastructure-4.3.2.jar:4.3.2]
	at org.springframework.batch.item.support.AbstractItemCountingItemStreamItemReader.read(AbstractItemCountingItemStreamItemReader.java:93) ~[spring-batch-infrastructure-4.3.2.jar:4.3.2]
	at org.springframework.batch.item.support.AbstractItemCountingItemStreamItemReader$$FastClassBySpringCGLIB$$ebb633d0.invoke(<generated>) ~[spring-batch-infrastructure-4.3.2.jar:4.3.2]
	at org.springframework.cglib.proxy.MethodProxy.invoke(MethodProxy.java:218) ~[spring-core-5.3.6.jar:5.3.6]
	at org.springframework.aop.framework.CglibAopProxy$CglibMethodInvocation.invokeJoinpoint(CglibAopProxy.java:779) ~[spring-aop-5.3.6.jar:5.3.6]
	at org.springframework.aop.framework.ReflectiveMethodInvocation.proceed(ReflectiveMethodInvocation.java:163) ~[spring-aop-5.3.6.jar:5.3.6]
	at org.springframework.aop.framework.CglibAopProxy$CglibMethodInvocation.proceed(CglibAopProxy.java:750) ~[spring-aop-5.3.6.jar:5.3.6]
	at org.springframework.aop.support.DelegatingIntroductionInterceptor.doProceed(DelegatingIntroductionInterceptor.java:137) ~[spring-aop-5.3.6.jar:5.3.6]
	at org.springframework.aop.support.DelegatingIntroductionInterceptor.invoke(DelegatingIntroductionInterceptor.java:124) ~[spring-aop-5.3.6.jar:5.3.6]
	at org.springframework.aop.framework.ReflectiveMethodInvocation.proceed(ReflectiveMethodInvocation.java:186) ~[spring-aop-5.3.6.jar:5.3.6]
	at org.springframework.aop.framework.CglibAopProxy$CglibMethodInvocation.proceed(CglibAopProxy.java:750) ~[spring-aop-5.3.6.jar:5.3.6]
	at org.springframework.aop.framework.CglibAopProxy$DynamicAdvisedInterceptor.intercept(CglibAopProxy.java:692) ~[spring-aop-5.3.6.jar:5.3.6]
	at org.springframework.batch.item.querydsl.reader.QuerydslNoOffsetPagingItemReader$$EnhancerBySpringCGLIB$$50409643.read(<generated>) ~[spring-batch-querydsl-reader-2.4.8.jar:na]
	at org.springframework.batch.core.step.item.SimpleChunkProvider.doRead(SimpleChunkProvider.java:99) ~[spring-batch-core-4.3.2.jar:4.3.2]
	at org.springframework.batch.core.step.item.SimpleChunkProvider.read(SimpleChunkProvider.java:180) ~[spring-batch-core-4.3.2.jar:4.3.2]
	at org.springframework.batch.core.step.item.SimpleChunkProvider$1.doInIteration(SimpleChunkProvider.java:126) ~[spring-batch-core-4.3.2.jar:4.3.2]
	at org.springframework.batch.repeat.support.RepeatTemplate.getNextResult(RepeatTemplate.java:375) ~[spring-batch-infrastructure-4.3.2.jar:4.3.2]
	at org.springframework.batch.repeat.support.RepeatTemplate.executeInternal(RepeatTemplate.java:215) ~[spring-batch-infrastructure-4.3.2.jar:4.3.2]
	at org.springframework.batch.repeat.support.RepeatTemplate.iterate(RepeatTemplate.java:145) ~[spring-batch-infrastructure-4.3.2.jar:4.3.2]
	at org.springframework.batch.core.step.item.SimpleChunkProvider.provide(SimpleChunkProvider.java:118) ~[spring-batch-core-4.3.2.jar:4.3.2]
	at org.springframework.batch.core.step.item.ChunkOrientedTasklet.execute(ChunkOrientedTasklet.java:71) ~[spring-batch-core-4.3.2.jar:4.3.2]
	at org.springframework.batch.core.step.tasklet.TaskletStep$ChunkTransactionCallback.doInTransaction(TaskletStep.java:407) ~[spring-batch-core-4.3.2.jar:4.3.2]
	at org.springframework.batch.core.step.tasklet.TaskletStep$ChunkTransactionCallback.doInTransaction(TaskletStep.java:331) ~[spring-batch-core-4.3.2.jar:4.3.2]
	at org.springframework.transaction.support.TransactionTemplate.execute(TransactionTemplate.java:140) ~[spring-tx-5.3.6.jar:5.3.6]
	at org.springframework.batch.core.step.tasklet.TaskletStep$2.doInChunkContext(TaskletStep.java:273) ~[spring-batch-core-4.3.2.jar:4.3.2]
	at org.springframework.batch.core.scope.context.StepContextRepeatCallback.doInIteration(StepContextRepeatCallback.java:82) ~[spring-batch-core-4.3.2.jar:4.3.2]
	at org.springframework.batch.repeat.support.RepeatTemplate.getNextResult(RepeatTemplate.java:375) ~[spring-batch-infrastructure-4.3.2.jar:4.3.2]
	at org.springframework.batch.repeat.support.RepeatTemplate.executeInternal(RepeatTemplate.java:215) ~[spring-batch-infrastructure-4.3.2.jar:4.3.2]
	at org.springframework.batch.repeat.support.RepeatTemplate.iterate(RepeatTemplate.java:145) ~[spring-batch-infrastructure-4.3.2.jar:4.3.2]
	at org.springframework.batch.core.step.tasklet.TaskletStep.doExecute(TaskletStep.java:258) ~[spring-batch-core-4.3.2.jar:4.3.2]
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method) ~[na:na]
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62) ~[na:na]
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43) ~[na:na]
	at java.base/java.lang.reflect.Method.invoke(Method.java:566) ~[na:na]
	at org.springframework.aop.support.AopUtils.invokeJoinpointUsingReflection(AopUtils.java:344) ~[spring-aop-5.3.6.jar:5.3.6]
	at org.springframework.aop.framework.ReflectiveMethodInvocation.invokeJoinpoint(ReflectiveMethodInvocation.java:198) ~[spring-aop-5.3.6.jar:5.3.6]
	at org.springframework.aop.framework.CglibAopProxy$CglibMethodInvocation.invokeJoinpoint(CglibAopProxy.java:782) ~[spring-aop-5.3.6.jar:5.3.6]
	at org.springframework.aop.framework.ReflectiveMethodInvocation.proceed(ReflectiveMethodInvocation.java:163) ~[spring-aop-5.3.6.jar:5.3.6]
	at org.springframework.aop.framework.CglibAopProxy$CglibMethodInvocation.proceed(CglibAopProxy.java:750) ~[spring-aop-5.3.6.jar:5.3.6]
	at org.springframework.aop.support.DelegatingIntroductionInterceptor.doProceed(DelegatingIntroductionInterceptor.java:137) ~[spring-aop-5.3.6.jar:5.3.6]
	at org.springframework.aop.support.DelegatingIntroductionInterceptor.invoke(DelegatingIntroductionInterceptor.java:124) ~[spring-aop-5.3.6.jar:5.3.6]
	at org.springframework.aop.framework.ReflectiveMethodInvocation.proceed(ReflectiveMethodInvocation.java:186) ~[spring-aop-5.3.6.jar:5.3.6]
	at org.springframework.aop.framework.CglibAopProxy$CglibMethodInvocation.proceed(CglibAopProxy.java:750) ~[spring-aop-5.3.6.jar:5.3.6]
	at org.springframework.aop.framework.CglibAopProxy$DynamicAdvisedInterceptor.intercept(CglibAopProxy.java:692) ~[spring-aop-5.3.6.jar:5.3.6]
	at org.springframework.batch.core.step.tasklet.TaskletStep$$EnhancerBySpringCGLIB$$47af1962.doExecute(<generated>) ~[spring-batch-core-4.3.2.jar:4.3.2]
	at org.springframework.batch.core.step.AbstractStep.execute(AbstractStep.java:208) ~[spring-batch-core-4.3.2.jar:4.3.2]
	at org.springframework.batch.core.job.SimpleStepHandler.handleStep(SimpleStepHandler.java:152) ~[spring-batch-core-4.3.2.jar:4.3.2]
	at org.springframework.batch.core.job.AbstractJob.handleStep(AbstractJob.java:413) ~[spring-batch-core-4.3.2.jar:4.3.2]
	at org.springframework.batch.core.job.SimpleJob.doExecute(SimpleJob.java:136) ~[spring-batch-core-4.3.2.jar:4.3.2]
	at org.springframework.batch.core.job.AbstractJob.execute(AbstractJob.java:320) ~[spring-batch-core-4.3.2.jar:4.3.2]
	at org.springframework.batch.core.launch.support.SimpleJobLauncher$1.run(SimpleJobLauncher.java:149) ~[spring-batch-core-4.3.2.jar:4.3.2]
	at org.springframework.core.task.SyncTaskExecutor.execute(SyncTaskExecutor.java:50) ~[spring-core-5.3.6.jar:5.3.6]
	at org.springframework.batch.core.launch.support.SimpleJobLauncher.run(SimpleJobLauncher.java:140) ~[spring-batch-core-4.3.2.jar:4.3.2]
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method) ~[na:na]
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62) ~[na:na]
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43) ~[na:na]
	at java.base/java.lang.reflect.Method.invoke(Method.java:566) ~[na:na]
	at org.springframework.aop.support.AopUtils.invokeJoinpointUsingReflection(AopUtils.java:344) ~[spring-aop-5.3.6.jar:5.3.6]
	at org.springframework.aop.framework.ReflectiveMethodInvocation.invokeJoinpoint(ReflectiveMethodInvocation.java:198) ~[spring-aop-5.3.6.jar:5.3.6]
	at org.springframework.aop.framework.ReflectiveMethodInvocation.proceed(ReflectiveMethodInvocation.java:163) ~[spring-aop-5.3.6.jar:5.3.6]
	at org.springframework.batch.core.configuration.annotation.SimpleBatchConfiguration$PassthruAdvice.invoke(SimpleBatchConfiguration.java:128) ~[spring-batch-core-4.3.2.jar:4.3.2]
	at org.springframework.aop.framework.ReflectiveMethodInvocation.proceed(ReflectiveMethodInvocation.java:186) ~[spring-aop-5.3.6.jar:5.3.6]
	at org.springframework.aop.framework.JdkDynamicAopProxy.invoke(JdkDynamicAopProxy.java:215) ~[spring-aop-5.3.6.jar:5.3.6]
	at com.sun.proxy.$Proxy90.run(Unknown Source) ~[na:na]
	at org.springframework.boot.autoconfigure.batch.JobLauncherApplicationRunner.execute(JobLauncherApplicationRunner.java:199) ~[spring-boot-autoconfigure-2.4.5.jar:2.4.5]
	at org.springframework.boot.autoconfigure.batch.JobLauncherApplicationRunner.executeLocalJobs(JobLauncherApplicationRunner.java:173) ~[spring-boot-autoconfigure-2.4.5.jar:2.4.5]
	at org.springframework.boot.autoconfigure.batch.JobLauncherApplicationRunner.launchJobFromProperties(JobLauncherApplicationRunner.java:160) ~[spring-boot-autoconfigure-2.4.5.jar:2.4.5]
	at org.springframework.boot.autoconfigure.batch.JobLauncherApplicationRunner.run(JobLauncherApplicationRunner.java:155) ~[spring-boot-autoconfigure-2.4.5.jar:2.4.5]
	at org.springframework.boot.autoconfigure.batch.JobLauncherApplicationRunner.run(JobLauncherApplicationRunner.java:150) ~[spring-boot-autoconfigure-2.4.5.jar:2.4.5]
	at org.springframework.boot.SpringApplication.callRunner(SpringApplication.java:810) ~[spring-boot-2.4.5.jar:2.4.5]
	at org.springframework.boot.SpringApplication.callRunners(SpringApplication.java:800) ~[spring-boot-2.4.5.jar:2.4.5]
	at org.springframework.boot.SpringApplication.run(SpringApplication.java:346) ~[spring-boot-2.4.5.jar:2.4.5]
	at org.springframework.boot.SpringApplication.run(SpringApplication.java:1340) ~[spring-boot-2.4.5.jar:2.4.5]
	at org.springframework.boot.SpringApplication.run(SpringApplication.java:1329) ~[spring-boot-2.4.5.jar:2.4.5]
	at com.batch.task.ReaderPerformanceApplicationKt.main(ReaderPerformanceApplication.kt:16) ~[main/:na]

2021-05-24 12:35:13.018 ERROR 23090 --- [           main] o.s.batch.core.step.AbstractStep         : Encountered an error executing step null in job readerPerformanceJob

java.lang.IllegalArgumentException: Not Found or Not Access Field
	at org.springframework.batch.item.querydsl.reader.options.QuerydslNoOffsetOptions.getFiledValue(QuerydslNoOffsetOptions.java:49) ~[spring-batch-querydsl-reader-2.4.8.jar:na]
	at org.springframework.batch.item.querydsl.reader.options.QuerydslNoOffsetNumberOptions.resetCurrentId(QuerydslNoOffsetNumberOptions.java:102) ~[spring-batch-querydsl-reader-2.4.8.jar:na]
	at org.springframework.batch.item.querydsl.reader.QuerydslNoOffsetPagingItemReader.resetCurrentIdIfNotLastPage(QuerydslNoOffsetPagingItemReader.java:58) ~[spring-batch-querydsl-reader-2.4.8.jar:na]
	at org.springframework.batch.item.querydsl.reader.QuerydslNoOffsetPagingItemReader.doReadPage(QuerydslNoOffsetPagingItemReader.java:44) ~[spring-batch-querydsl-reader-2.4.8.jar:na]
	at org.springframework.batch.item.database.AbstractPagingItemReader.doRead(AbstractPagingItemReader.java:110) ~[spring-batch-infrastructure-4.3.2.jar:4.3.2]
	at org.springframework.batch.item.support.AbstractItemCountingItemStreamItemReader.read(AbstractItemCountingItemStreamItemReader.java:93) ~[spring-batch-infrastructure-4.3.2.jar:4.3.2]
	at org.springframework.batch.item.support.AbstractItemCountingItemStreamItemReader$$FastClassBySpringCGLIB$$ebb633d0.invoke(<generated>) ~[spring-batch-infrastructure-4.3.2.jar:4.3.2]
	at org.springframework.cglib.proxy.MethodProxy.invoke(MethodProxy.java:218) ~[spring-core-5.3.6.jar:5.3.6]
	at org.springframework.aop.framework.CglibAopProxy$CglibMethodInvocation.invokeJoinpoint(CglibAopProxy.java:779) ~[spring-aop-5.3.6.jar:5.3.6]
	at org.springframework.aop.framework.ReflectiveMethodInvocation.proceed(ReflectiveMethodInvocation.java:163) ~[spring-aop-5.3.6.jar:5.3.6]
	at org.springframework.aop.framework.CglibAopProxy$CglibMethodInvocation.proceed(CglibAopProxy.java:750) ~[spring-aop-5.3.6.jar:5.3.6]
	at org.springframework.aop.support.DelegatingIntroductionInterceptor.doProceed(DelegatingIntroductionInterceptor.java:137) ~[spring-aop-5.3.6.jar:5.3.6]
	at org.springframework.aop.support.DelegatingIntroductionInterceptor.invoke(DelegatingIntroductionInterceptor.java:124) ~[spring-aop-5.3.6.jar:5.3.6]
	at org.springframework.aop.framework.ReflectiveMethodInvocation.proceed(ReflectiveMethodInvocation.java:186) ~[spring-aop-5.3.6.jar:5.3.6]
	at org.springframework.aop.framework.CglibAopProxy$CglibMethodInvocation.proceed(CglibAopProxy.java:750) ~[spring-aop-5.3.6.jar:5.3.6]
	at org.springframework.aop.framework.CglibAopProxy$DynamicAdvisedInterceptor.intercept(CglibAopProxy.java:692) ~[spring-aop-5.3.6.jar:5.3.6]
	at org.springframework.batch.item.querydsl.reader.QuerydslNoOffsetPagingItemReader$$EnhancerBySpringCGLIB$$50409643.read(<generated>) ~[spring-batch-querydsl-reader-2.4.8.jar:na]
	at org.springframework.batch.core.step.item.SimpleChunkProvider.doRead(SimpleChunkProvider.java:99) ~[spring-batch-core-4.3.2.jar:4.3.2]
	at org.springframework.batch.core.step.item.SimpleChunkProvider.read(SimpleChunkProvider.java:180) ~[spring-batch-core-4.3.2.jar:4.3.2]
	at org.springframework.batch.core.step.item.SimpleChunkProvider$1.doInIteration(SimpleChunkProvider.java:126) ~[spring-batch-core-4.3.2.jar:4.3.2]
	at org.springframework.batch.repeat.support.RepeatTemplate.getNextResult(RepeatTemplate.java:375) ~[spring-batch-infrastructure-4.3.2.jar:4.3.2]
	at org.springframework.batch.repeat.support.RepeatTemplate.executeInternal(RepeatTemplate.java:215) ~[spring-batch-infrastructure-4.3.2.jar:4.3.2]
	at org.springframework.batch.repeat.support.RepeatTemplate.iterate(RepeatTemplate.java:145) ~[spring-batch-infrastructure-4.3.2.jar:4.3.2]
	at org.springframework.batch.core.step.item.SimpleChunkProvider.provide(SimpleChunkProvider.java:118) ~[spring-batch-core-4.3.2.jar:4.3.2]
	at org.springframework.batch.core.step.item.ChunkOrientedTasklet.execute(ChunkOrientedTasklet.java:71) ~[spring-batch-core-4.3.2.jar:4.3.2]
	at org.springframework.batch.core.step.tasklet.TaskletStep$ChunkTransactionCallback.doInTransaction(TaskletStep.java:407) ~[spring-batch-core-4.3.2.jar:4.3.2]
	at org.springframework.batch.core.step.tasklet.TaskletStep$ChunkTransactionCallback.doInTransaction(TaskletStep.java:331) ~[spring-batch-core-4.3.2.jar:4.3.2]
	at org.springframework.transaction.support.TransactionTemplate.execute(TransactionTemplate.java:140) ~[spring-tx-5.3.6.jar:5.3.6]
	at org.springframework.batch.core.step.tasklet.TaskletStep$2.doInChunkContext(TaskletStep.java:273) ~[spring-batch-core-4.3.2.jar:4.3.2]
	at org.springframework.batch.core.scope.context.StepContextRepeatCallback.doInIteration(StepContextRepeatCallback.java:82) ~[spring-batch-core-4.3.2.jar:4.3.2]
	at org.springframework.batch.repeat.support.RepeatTemplate.getNextResult(RepeatTemplate.java:375) ~[spring-batch-infrastructure-4.3.2.jar:4.3.2]
	at org.springframework.batch.repeat.support.RepeatTemplate.executeInternal(RepeatTemplate.java:215) ~[spring-batch-infrastructure-4.3.2.jar:4.3.2]
	at org.springframework.batch.repeat.support.RepeatTemplate.iterate(RepeatTemplate.java:145) ~[spring-batch-infrastructure-4.3.2.jar:4.3.2]
	at org.springframework.batch.core.step.tasklet.TaskletStep.doExecute(TaskletStep.java:258) ~[spring-batch-core-4.3.2.jar:4.3.2]
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method) ~[na:na]
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62) ~[na:na]
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43) ~[na:na]
	at java.base/java.lang.reflect.Method.invoke(Method.java:566) ~[na:na]
	at org.springframework.aop.support.AopUtils.invokeJoinpointUsingReflection(AopUtils.java:344) ~[spring-aop-5.3.6.jar:5.3.6]
	at org.springframework.aop.framework.ReflectiveMethodInvocation.invokeJoinpoint(ReflectiveMethodInvocation.java:198) ~[spring-aop-5.3.6.jar:5.3.6]
	at org.springframework.aop.framework.CglibAopProxy$CglibMethodInvocation.invokeJoinpoint(CglibAopProxy.java:782) ~[spring-aop-5.3.6.jar:5.3.6]
	at org.springframework.aop.framework.ReflectiveMethodInvocation.proceed(ReflectiveMethodInvocation.java:163) ~[spring-aop-5.3.6.jar:5.3.6]
	at org.springframework.aop.framework.CglibAopProxy$CglibMethodInvocation.proceed(CglibAopProxy.java:750) ~[spring-aop-5.3.6.jar:5.3.6]
	at org.springframework.aop.support.DelegatingIntroductionInterceptor.doProceed(DelegatingIntroductionInterceptor.java:137) ~[spring-aop-5.3.6.jar:5.3.6]
	at org.springframework.aop.support.DelegatingIntroductionInterceptor.invoke(DelegatingIntroductionInterceptor.java:124) ~[spring-aop-5.3.6.jar:5.3.6]
	at org.springframework.aop.framework.ReflectiveMethodInvocation.proceed(ReflectiveMethodInvocation.java:186) ~[spring-aop-5.3.6.jar:5.3.6]
	at org.springframework.aop.framework.CglibAopProxy$CglibMethodInvocation.proceed(CglibAopProxy.java:750) ~[spring-aop-5.3.6.jar:5.3.6]
	at org.springframework.aop.framework.CglibAopProxy$DynamicAdvisedInterceptor.intercept(CglibAopProxy.java:692) ~[spring-aop-5.3.6.jar:5.3.6]
	at org.springframework.batch.core.step.tasklet.TaskletStep$$EnhancerBySpringCGLIB$$47af1962.doExecute(<generated>) ~[spring-batch-core-4.3.2.jar:4.3.2]
	at org.springframework.batch.core.step.AbstractStep.execute(AbstractStep.java:208) ~[spring-batch-core-4.3.2.jar:4.3.2]
	at org.springframework.batch.core.job.SimpleStepHandler.handleStep(SimpleStepHandler.java:152) ~[spring-batch-core-4.3.2.jar:4.3.2]
	at org.springframework.batch.core.job.AbstractJob.handleStep(AbstractJob.java:413) ~[spring-batch-core-4.3.2.jar:4.3.2]
	at org.springframework.batch.core.job.SimpleJob.doExecute(SimpleJob.java:136) ~[spring-batch-core-4.3.2.jar:4.3.2]
	at org.springframework.batch.core.job.AbstractJob.execute(AbstractJob.java:320) ~[spring-batch-core-4.3.2.jar:4.3.2]
	at org.springframework.batch.core.launch.support.SimpleJobLauncher$1.run(SimpleJobLauncher.java:149) ~[spring-batch-core-4.3.2.jar:4.3.2]
	at org.springframework.core.task.SyncTaskExecutor.execute(SyncTaskExecutor.java:50) ~[spring-core-5.3.6.jar:5.3.6]
	at org.springframework.batch.core.launch.support.SimpleJobLauncher.run(SimpleJobLauncher.java:140) ~[spring-batch-core-4.3.2.jar:4.3.2]
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method) ~[na:na]
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62) ~[na:na]
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43) ~[na:na]
	at java.base/java.lang.reflect.Method.invoke(Method.java:566) ~[na:na]
	at org.springframework.aop.support.AopUtils.invokeJoinpointUsingReflection(AopUtils.java:344) ~[spring-aop-5.3.6.jar:5.3.6]
	at org.springframework.aop.framework.ReflectiveMethodInvocation.invokeJoinpoint(ReflectiveMethodInvocation.java:198) ~[spring-aop-5.3.6.jar:5.3.6]
	at org.springframework.aop.framework.ReflectiveMethodInvocation.proceed(ReflectiveMethodInvocation.java:163) ~[spring-aop-5.3.6.jar:5.3.6]
	at org.springframework.batch.core.configuration.annotation.SimpleBatchConfiguration$PassthruAdvice.invoke(SimpleBatchConfiguration.java:128) ~[spring-batch-core-4.3.2.jar:4.3.2]
	at org.springframework.aop.framework.ReflectiveMethodInvocation.proceed(ReflectiveMethodInvocation.java:186) ~[spring-aop-5.3.6.jar:5.3.6]
	at org.springframework.aop.framework.JdkDynamicAopProxy.invoke(JdkDynamicAopProxy.java:215) ~[spring-aop-5.3.6.jar:5.3.6]
	at com.sun.proxy.$Proxy90.run(Unknown Source) ~[na:na]
	at org.springframework.boot.autoconfigure.batch.JobLauncherApplicationRunner.execute(JobLauncherApplicationRunner.java:199) ~[spring-boot-autoconfigure-2.4.5.jar:2.4.5]
	at org.springframework.boot.autoconfigure.batch.JobLauncherApplicationRunner.executeLocalJobs(JobLauncherApplicationRunner.java:173) ~[spring-boot-autoconfigure-2.4.5.jar:2.4.5]
	at org.springframework.boot.autoconfigure.batch.JobLauncherApplicationRunner.launchJobFromProperties(JobLauncherApplicationRunner.java:160) ~[spring-boot-autoconfigure-2.4.5.jar:2.4.5]
	at org.springframework.boot.autoconfigure.batch.JobLauncherApplicationRunner.run(JobLauncherApplicationRunner.java:155) ~[spring-boot-autoconfigure-2.4.5.jar:2.4.5]
	at org.springframework.boot.autoconfigure.batch.JobLauncherApplicationRunner.run(JobLauncherApplicationRunner.java:150) ~[spring-boot-autoconfigure-2.4.5.jar:2.4.5]
	at org.springframework.boot.SpringApplication.callRunner(SpringApplication.java:810) ~[spring-boot-2.4.5.jar:2.4.5]
	at org.springframework.boot.SpringApplication.callRunners(SpringApplication.java:800) ~[spring-boot-2.4.5.jar:2.4.5]
	at org.springframework.boot.SpringApplication.run(SpringApplication.java:346) ~[spring-boot-2.4.5.jar:2.4.5]
	at org.springframework.boot.SpringApplication.run(SpringApplication.java:1340) ~[spring-boot-2.4.5.jar:2.4.5]
	at org.springframework.boot.SpringApplication.run(SpringApplication.java:1329) ~[spring-boot-2.4.5.jar:2.4.5]
	at com.batch.task.ReaderPerformanceApplicationKt.main(ReaderPerformanceApplication.kt:16) ~[main/:na]
```

</details>

## 해결
```java
protected Object getFiledValue(T item) {
        try {
            final Class<?> itemClass = item.getClass();
            if (itemClass.getSuperclass() != null) {
                final Class<?> superclass = itemClass.getSuperclass();
                final Field[] superClassFields = superclass.getDeclaredFields();
                for (Field field : superClassFields) {
                    if (field.getName().equals(fieldName)) {
                        field.setAccessible(true);
                        superclass.getDeclaredField("id");
                        return field.get(item);
                    }
                }
            }

            final Field field = itemClass.getDeclaredField("id");
            field.setAccessible(true);
            return field.get(item);
        } catch (NoSuchFieldException | IllegalAccessException e) {
            logger.error("Not Found or Not Access Field= " + fieldName, e);
            throw new IllegalArgumentException("Not Found or Not Access Field");
        }
    }
```
해당 클래스가 슈퍼 클래스를 상속 받으면 해당 필드를 슈퍼 클래스에서 찾고 없으면 기존 코드의 자신의 필드에서 찾게 변경